### PR TITLE
travis/appveyor: Update MongoDB Libraries (#395)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,17 +17,17 @@ install:
 - set CMAKE_INCLUDE_PATH=%CMAKE_INCLUDE_PATH%;%CD%
 - cd ..
 # build libbson
-- appveyor DownloadFile https://github.com/mongodb/libbson/archive/1.5.0.zip -FileName libbson-1.5.0.zip
-- 7z x libbson-1.5.0.zip
-- cd libbson-1.5.0
+- appveyor DownloadFile https://github.com/mongodb/libbson/archive/1.9.3.zip -FileName libbson-1.9.3.zip
+- 7z x libbson-1.9.3.zip
+- cd libbson-1.9.3
 - cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\libraries\libbson -DENABLE_TESTS=OFF
 - msbuild /p:Configuration=Release ALL_BUILD.vcxproj
 - msbuild /p:Configuration=Release INSTALL.vcxproj
 - cd ..
 # build mongoc
-- appveyor DownloadFile https://github.com/mongodb/mongo-c-driver/archive/1.5.0.zip -FileName mongo-c-driver-1.5.0.zip
-- 7z x mongo-c-driver-1.5.0.zip
-- cd mongo-c-driver-1.5.0
+- appveyor DownloadFile https://github.com/mongodb/mongo-c-driver/archive/1.9.3.zip -FileName mongo-c-driver-1.9.3.zip
+- 7z x mongo-c-driver-1.9.3.zip
+- cd mongo-c-driver-1.9.3
 - cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\libraries\mongoc -DENABLE_SSL=OFF -DENABLE_TESTS=OFF -DBSON_ROOT_DIR=C:\libraries\libbson
 - msbuild /p:Configuration=Release ALL_BUILD.vcxproj
 - msbuild /p:Configuration=Release INSTALL.vcxproj
@@ -35,7 +35,7 @@ install:
 # build mongo-cxx-driver
 - git clone --branch releases/stable https://github.com/mongodb/mongo-cxx-driver
 - cd mongo-cxx-driver\build
-- cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\libraries\mongo-cxx-driver -DLIBBSON_DIR=C:\libraries\libbson -DLIBMONGOC_DIR=C:\libraries\mongoc ..
+- cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\libraries\mongo-cxx-driver -DCMAKE_PREFIX_PATH=C:\libraries\libbson;C:\libraries\mongoc -DLIBMONGOC_DIR=C:\libraries\mongoc ..
 - msbuild /p:Configuration=Release ALL_BUILD.vcxproj
 - msbuild /p:Configuration=Release INSTALL.vcxproj
 - cd ..\..\..
@@ -43,7 +43,7 @@ install:
 
 build_script:
 - cd build
-- cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_USE_STATIC_LIBS=NO ..
+- cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\libraries\mongo-cxx-driver -DCMAKE_PREFIX_PATH=C:\libraries\libbson;C:\libraries\mongoc -DCMAKE_BUILD_TYPE=Release -DOPENSSL_USE_STATIC_LIBS=NO ..
 - msbuild /p:Configuration=Release ALL_BUILD.vcxproj
 - cd Release
 - copy /Y C:\libraries\libbson\bin\*.dll .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,17 @@ os:
 dist: trusty
 sudo: required
 
-osx_image: xcode7.3
+osx_image: xcode8.3
 
 compiler:
 - clang
 - gcc
-
+services:
+    - mongodb
 addons:
   apt:
+    sources:
+    - mongodb-3.0-trusty
     packages:
     - cmake
     - libboost-filesystem-dev
@@ -22,22 +25,22 @@ addons:
     - libboost-thread-dev
     - libssl-dev
     - libyaml-cpp-dev
-    - mongodb-server
+    - mongodb-org-server
 
 before_install:
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update;
     brew outdated boost || brew upgrade boost;
-    brew install openssl && export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j/
+    brew upgrade openssl && export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2n/
     brew install yaml-cpp;
     brew install mongodb;
   fi
 
 install:
 - OLD_PWD=$PWD
-- cd ~/build && wget https://github.com/mongodb/libbson/releases/download/1.5.0/libbson-1.5.0.tar.gz && tar xzf libbson-1.5.0.tar.gz && cd libbson-1.5.0 && ./configure && make && sudo make install
-- cd ~/build && wget https://github.com/mongodb/mongo-c-driver/releases/download/1.5.0/mongo-c-driver-1.5.0.tar.gz && tar xzf mongo-c-driver-1.5.0.tar.gz && cd mongo-c-driver-1.5.0 && ./configure && make && sudo make install
+- cd ~/build && wget https://github.com/mongodb/libbson/releases/download/1.9.3/libbson-1.9.3.tar.gz && tar xzf libbson-1.9.3.tar.gz && cd libbson-1.9.3 && ./configure && make && sudo make install
+- cd ~/build && wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz && tar xzf mongo-c-driver-1.9.3.tar.gz && cd mongo-c-driver-1.9.3 && ./configure && make && sudo make install
 - cd ~/build && git clone https://github.com/mongodb/mongo-cxx-driver && cd mongo-cxx-driver/build && git checkout releases/stable && cmake .. && make && make install && sudo cp -r install/* /usr/local
 - cd $OLD_PWD
 


### PR DESCRIPTION
* build: make mongo libraries up-to-date

AppVeyor & Travis builds were previously failing because of incompatibility between older libraries and the latest mongo-cxx library.

* travis: update xcode and mongodb server

Should fix any other travis build errors

* travis: fix ssl on osx